### PR TITLE
Added remove method in panel + Fix Phaser.Game reference in keyboard.

### DIFF
--- a/src/Element/Panel.js
+++ b/src/Element/Panel.js
@@ -66,6 +66,18 @@ SlickUI.Element.Panel.prototype.add = function (element) {
     return this.container.add(element);
 };
 
+/**
+ * Destroys the panel, removing from world.
+ */
+SlickUI.Element.Panel.prototype.destroy = function() {
+
+    this.container.displayGroup.removeAll(true);
+    this.container.displayGroup.destroy();
+    this.container.children = [];
+    this.container = undefined;
+    this.sprite = undefined;
+};
+
 
 /* ------------------------------- */
 

--- a/src/Keyboard/Key.js
+++ b/src/Keyboard/Key.js
@@ -7,7 +7,7 @@ SlickUI.namespace('Keyboard');
  * @constructor
  */
 SlickUI.Keyboard.Key = function(plugin, x, y, width, height, font, fontSize, text) {
-    this.group = game.add.group();
+    this.group = plugin.game.add.group();
     this.font = font;
     this._x = x;
     this._y = y;


### PR DESCRIPTION
I'm using Slick-UI in a professional project and I found some issues. Made some workarounds to handle them.

There's no destroy method for Slick-UI elements. (I think putting visible = false it's not much acceptable due to resource usage reasons). I implemented a basic one for `SlickUI.Element.Panel`. (Most used element I guess).

There's a reference to `Phaser.Game `element in `SlickUI.Keyboard.Key`, that doesn't work in some environments. In the code it references to "game", that didn't work when game is not defined as `Phaser.Game`. Replaced with Slick-UI `Phaser.Game` reference (`plugin.game`).

Any improvement to the code will be appreciated. 

P.S. That's a good lib :) Good work! 